### PR TITLE
Add intentOnFilling to integrate RFQ liquidity

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ open http://localhost:3000
 
 #### RFQ Integration on Swap API
 
-- [**How to Integrate RFQ Liquidity**](https://0x.org/docs/0x-swap-api/guides/accessing-rfq-liquidity/how-to-integrate-rfq-liquidity)0
+- [**How to Integrate RFQ Liquidity**](https://0x.org/docs/0x-swap-api/guides/accessing-rfq-liquidity/how-to-integrate-rfq-liquidity)

--- a/README.md
+++ b/README.md
@@ -36,9 +36,20 @@ open http://localhost:3000
 
 ## Resources
 
+### Video
+
 🎥 Watch [this video](https://www.youtube.com/watch?v=P1ECx9zKQiU) for an walk-through of this app.
 
-- **📚 Swap API Docs:** https://0x.org/docs/0x-swap-api/introduction
-- **Quote API Endpoint:** https://0x.org/docs/0x-swap-api/api-references/get-swap-v1-quote
-- **Price API Endpoint:** https://0x.org/docs/0x-swap-api/api-references/get-swap-v1-price
-- **⛓️ Swap API Endpoints on All Networks:** https://0x.org/docs/introduction/0x-cheat-sheet
+### Documentation
+
+#### Swap API Basics
+
+- [**📚 Swap API Docs**](https://0x.org/docs/0x-swap-api/introduction)
+- [**How to Use Swap API**](https://0x.org/docs/0x-swap-api/guides/swap-tokens-with-0x-swap-api)
+- [**Quote API Endpoint**](https://0x.org/docs/0x-swap-api/api-references/get-swap-v1-quote)
+- [**Price API Endpoint**](https://0x.org/docs/0x-swap-api/api-references/get-swap-v1-price)
+- [**⛓️ Swap API Endpoints on All Networks**](https://0x.org/docs/introduction/0x-cheat-sheet)
+
+#### RFQ Integration on Swap API
+
+- [**How to Integrate RFQ Liquidity**](https://0x.org/docs/0x-swap-api/guides/accessing-rfq-liquidity/how-to-integrate-rfq-liquidity)0

--- a/pages/Quote/index.tsx
+++ b/pages/Quote/index.tsx
@@ -37,6 +37,7 @@ export default function QuoteView({
         buyToken: price.buyTokenAddress,
         sellAmount: price.sellAmount,
         // buyAmount: TODO if we want to support buys,
+        intentOnFilling: true, // Used to enable RFQ liquidity
         takerAddress,
       },
     ],


### PR DESCRIPTION
~~As part of the RFQ Activate campaign, we want to encourage integrators to turn on RFQ. Adding RFQ integration by default in our demo app.~~
Mike is actively working on removing `intentToFill` parameter ([ticket](https://linear.app/0xproject/issue/RFQ-1212/remove-intentonfilling-query-param)) so this PR is not needed anymore 🙌 