### PR TITLE
add option for maticand logic to handle the native token

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -21,6 +21,15 @@ interface Token {
 export const POLYGON_TOKENS: Token[] = [
   {
     chainId: 137,
+    name: "Matic",
+    symbol: "MATIC",
+    decimals: 18,
+    address: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    logoURI:
+      "https://raw.githubusercontent.com/maticnetwork/polygon-token-assets/main/assets/tokenAssets/matic.svg",
+  },
+  {
+    chainId: 137,
     name: "Wrapped Matic",
     symbol: "WMATIC",
     decimals: 18,
@@ -67,6 +76,15 @@ export const POLYGON_TOKENS: Token[] = [
 ];
 
 export const POLYGON_TOKENS_BY_SYMBOL: Record<string, Token> = {
+  matic: {
+    chainId: 137,
+    name: "Matic",
+    symbol: "MATIC",
+    decimals: 18,
+    address: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    logoURI:
+      "https://raw.githubusercontent.com/maticnetwork/polygon-token-assets/main/assets/tokenAssets/matic.svg",
+  },
   wmatic: {
     chainId: 137,
     name: "Wrapped Matic",
@@ -115,6 +133,15 @@ export const POLYGON_TOKENS_BY_SYMBOL: Record<string, Token> = {
 };
 
 export const POLYGON_TOKENS_BY_ADDRESS: Record<string, Token> = {
+  "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
+    chainId: 137,
+    name: "Matic",
+    symbol: "MATIC",
+    decimals: 18,
+    address: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    logoURI:
+      "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/polygon/assets/0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270/logo.png",
+  },
   "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270": {
     chainId: 137,
     name: "Wrapped Matic",

--- a/pages/Price/index.tsx
+++ b/pages/Price/index.tsx
@@ -12,6 +12,7 @@ import {
   useBalance,
   type Address,
 } from "wagmi";
+import { polygon } from "wagmi/chains";
 import {
   POLYGON_TOKENS,
   POLYGON_TOKENS_BY_SYMBOL,
@@ -66,7 +67,7 @@ export default function PriceView({
 
   const sellTokenDecimals = POLYGON_TOKENS_BY_SYMBOL[sellToken].decimals;
 
-  console.log(sellAmount, sellTokenDecimals, "<-");
+  console.log("sellAmount", sellAmount, "sellTokenDecimals", sellTokenDecimals);
   const parsedSellAmount =
     sellAmount && tradeDirection === "sell"
       ? parseUnits(sellAmount, sellTokenDecimals).toString()
@@ -98,7 +99,12 @@ export default function PriceView({
       onSuccess: (data) => {
         setPrice(data);
         if (tradeDirection === "sell") {
-          console.log(formatUnits(data.buyAmount, buyTokenDecimals), data);
+          console.log(
+            "formatted buyAmount",
+            formatUnits(data.buyAmount, buyTokenDecimals),
+            "data",
+            data
+          );
           setBuyAmount(formatUnits(data.buyAmount, buyTokenDecimals));
         } else {
           setSellAmount(formatUnits(data.sellAmount, sellTokenDecimals));
@@ -107,19 +113,31 @@ export default function PriceView({
     }
   );
 
+  // Conditionally set the token address
+  const tokenAddress =
+    sellToken.toLowerCase() === "matic"
+      ? undefined
+      : POLYGON_TOKENS_BY_SYMBOL[sellToken]?.address;
+
   const { data, isError, isLoading } = useBalance({
     address: takerAddress,
-    token: POLYGON_TOKENS_BY_SYMBOL[sellToken].address,
+    token: tokenAddress,
   });
+  console.log(
+    "address",
+    takerAddress,
+    "token",
+    POLYGON_TOKENS_BY_SYMBOL[sellToken].address
+  );
 
-  console.log(sellAmount);
+  console.log("sellAmount", sellAmount);
 
   const disabled =
     data && sellAmount
       ? parseUnits(sellAmount, sellTokenDecimals) > data.value
       : true;
 
-  console.log(data, isError, isLoading);
+  console.log("data", data, "isError", isError, "isLoading", isLoading);
 
   return (
     <form>


### PR DESCRIPTION
Native tokens are a special case. Add MATIC as an option to show how to handle native tokens

We are using wagmi’s [useBalance](https://1.x.wagmi.sh/react/hooks/useBalance) to check if the connected wallet has enough of the selected token. Typically, we can pass the token address as a parameter to `useBalance`; however, for native tokens, `useBalance` doesn’t actually take an address (0x uses `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` to represent native tokens. While this is common for many dapps, it is not universal; hence, this case for `useBalance`)

Notice the description for [useBalance](https://wagmi.sh/react/api/hooks/useBalance#action) tries to distinguishes between native and token (ERC20) balances: 

<img width="522" alt="image" src="https://github.com/user-attachments/assets/7b880c3e-d51c-4971-8013-863621e6b795">


Adding logic to conditionally set the token address
```
  const tokenAddress =
    sellToken.toLowerCase() === "matic"
      ? undefined
      : POLYGON_TOKENS_BY_SYMBOL[sellToken]?.address;

  const { data, isError, isLoading } = useBalance({
    address: takerAddress,
    token: tokenAddress,
  });
```